### PR TITLE
Update JavadocBlockTagLocationCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -382,13 +382,13 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
             if (waitsForProcessing) {
                 visitJavadocToken(curNode);
             }
-            DetailNode toVisit = JavadocUtil.getFirstChild(curNode);
+            DetailNode toVisit = curNode.getFirstChild();
             while (curNode != null && toVisit == null) {
                 if (waitsForProcessing) {
                     leaveJavadocToken(curNode);
                 }
 
-                toVisit = JavadocUtil.getNextSibling(curNode);
+                toVisit = curNode.getNextSibling();
                 curNode = curNode.getParent();
                 if (curNode != null) {
                     waitsForProcessing = shouldBeProcessed(curNode);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 
 /**
@@ -173,7 +174,7 @@ public class JavadocBlockTagLocationCheck extends AbstractJavadocCheck {
     @Override
     public int[] getRequiredJavadocTokens() {
         return new int[] {
-            JavadocTokenTypes.TEXT,
+                JavadocCommentsTokenTypes.TEXT,
         };
     }
 
@@ -207,8 +208,19 @@ public class JavadocBlockTagLocationCheck extends AbstractJavadocCheck {
      * @return {@code true} if node is {@code @code}, {@code @literal} or HTML comment.
      */
     private static boolean isCommentOrInlineTag(DetailNode node) {
-        return node.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG
-                || node.getType() == JavadocTokenTypes.HTML_COMMENT;
+        boolean isInsideInlineTagOrHtmlComment = false;
+        DetailNode current = node;
+
+        while (current != null) {
+            if (current.getType() == JavadocCommentsTokenTypes.JAVADOC_INLINE_TAG
+                    || current.getType() == JavadocCommentsTokenTypes.HTML_COMMENT) {
+                isInsideInlineTagOrHtmlComment = true;
+                break;
+            }
+            current = current.getParent();
+        }
+
+        return isInsideInlineTagOrHtmlComment;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
@@ -22,14 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.MSG_BLOCK_TAG_LOCATION;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
-@Disabled
 public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport {
 
     @Override
@@ -41,7 +39,7 @@ public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport 
     public void testGetAcceptableTokens() {
         final JavadocBlockTagLocationCheck checkObj = new JavadocBlockTagLocationCheck();
         final int[] expected = {
-            JavadocTokenTypes.TEXT,
+            JavadocCommentsTokenTypes.TEXT,
         };
         assertWithMessage("Default acceptable tokens are invalid")
             .that(checkObj.getAcceptableJavadocTokens())


### PR DESCRIPTION
This check update required a small modification in the parser to be able to parse html comments