### PR TITLE
Update SingleLineJavadocCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -269,7 +269,7 @@ public class JavadocNodeImpl implements DetailNode {
 
     @Override
     public String toString() {
-        return text + "[" + lineNumber + "x" + columnNumber + "]";
+        return text + "[" + getLineNumber() + "x" + getColumnNumber() + "]";
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
-import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
@@ -135,7 +135,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     @Override
     public int[] getDefaultJavadocTokens() {
         return new int[] {
-            JavadocTokenTypes.JAVADOC,
+            JavadocCommentsTokenTypes.JAVADOC_CONTENT,
         };
     }
 
@@ -176,7 +176,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      */
     private boolean hasJavadocTags(DetailNode javadocRoot) {
         final DetailNode javadocTagSection =
-                JavadocUtil.findFirstToken(javadocRoot, JavadocTokenTypes.JAVADOC_TAG);
+                JavadocUtil.findFirstToken(javadocRoot, JavadocCommentsTokenTypes.JAVADOC_BLOCK_TAG);
         return javadocTagSection != null && !isTagIgnored(javadocTagSection);
     }
 
@@ -191,7 +191,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      */
     private boolean hasJavadocInlineTags(DetailNode javadocRoot) {
         DetailNode javadocTagSection =
-                JavadocUtil.findFirstToken(javadocRoot, JavadocTokenTypes.JAVADOC_INLINE_TAG);
+                JavadocUtil.findFirstToken(javadocRoot, JavadocCommentsTokenTypes.JAVADOC_INLINE_TAG);
         boolean foundTag = false;
         while (javadocTagSection != null) {
             if (!isTagIgnored(javadocTagSection)) {
@@ -199,7 +199,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
                 break;
             }
             javadocTagSection = JavadocUtil.getNextSibling(
-                    javadocTagSection, JavadocTokenTypes.JAVADOC_INLINE_TAG);
+                    javadocTagSection, JavadocCommentsTokenTypes.JAVADOC_INLINE_TAG);
         }
         return foundTag;
     }
@@ -211,7 +211,8 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      * @return true, if ignoredTags contains javadocTagSection's javadoc tag.
      */
     private boolean isTagIgnored(DetailNode javadocTagSection) {
-        return ignoredTags.contains(JavadocUtil.getTagName(javadocTagSection));
+        String tagName = JavadocUtil.getTagName(javadocTagSection);
+        return ignoredTags.contains("@" + tagName);
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java
@@ -198,13 +198,13 @@ public final class JavadocUtil {
      */
     public static DetailNode findFirstToken(DetailNode detailNode, int type) {
         DetailNode returnValue = null;
-        DetailNode node = getFirstChild(detailNode);
+        DetailNode node = detailNode.getFirstChild();
         while (node != null) {
             if (node.getType() == type) {
                 returnValue = node;
                 break;
             }
-            node = getNextSibling(node);
+            node = node.getNextSibling();
         }
         return returnValue;
     }
@@ -251,9 +251,9 @@ public final class JavadocUtil {
      * @return next sibling.
      */
     public static DetailNode getNextSibling(DetailNode node, int tokenType) {
-        DetailNode nextSibling = getNextSibling(node);
+        DetailNode nextSibling = node.getNextSibling();
         while (nextSibling != null && nextSibling.getType() != tokenType) {
-            nextSibling = getNextSibling(nextSibling);
+            nextSibling = nextSibling.getNextSibling();
         }
         return nextSibling;
     }
@@ -321,21 +321,16 @@ public final class JavadocUtil {
     }
 
     /**
-     * Gets tag name from javadocTagSection.
+     * Extracts the tag name from the given Javadoc tag section.
      *
-     * @param javadocTagSection to get tag name from.
-     * @return name, of the javadocTagSection's tag.
+     * @param javadocTagSection the node representing a Javadoc tag section.
+     *       This node must be of type {@link JavadocCommentsTokenTypes#JAVADOC_BLOCK_TAG}
+     *       or {@link JavadocCommentsTokenTypes#JAVADOC_INLINE_TAG}.
+     *  @return the tag name (e.g., "param", "return", "link")
      */
     public static String getTagName(DetailNode javadocTagSection) {
-        final String javadocTagName;
-        if (javadocTagSection.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
-            javadocTagName = getNextSibling(
-                    getFirstChild(javadocTagSection)).getText();
-        }
-        else {
-            javadocTagName = getFirstChild(javadocTagSection).getText();
-        }
-        return javadocTagName;
+        return findFirstToken(javadocTagSection.getFirstChild(),
+                    JavadocCommentsTokenTypes.TAG_NAME).getText();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
@@ -22,13 +22,11 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck.MSG_KEY;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-@Disabled
 public class SingleLineJavadocCheckTest extends AbstractModuleTestSupport {
 
     @Override


### PR DESCRIPTION
Cherry-picked the correct commit from [#26](https://github.com/checkstyle-GSoC25/checkstyle/pull/26) after version control got messed up in the original branch due to an incorrect rebase. This branch preserves a clean history.