### PR TITLE
Updare AtclauseOrderCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
-import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
@@ -173,7 +173,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     @Override
     public int[] getDefaultJavadocTokens() {
         return new int[] {
-            JavadocTokenTypes.JAVADOC,
+            JavadocCommentsTokenTypes.JAVADOC_CONTENT,
         };
     }
 
@@ -198,11 +198,12 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
      */
     private void checkOrderInTagSection(DetailNode javadoc) {
         int maxIndexOfPreviousTag = 0;
+        DetailNode node = javadoc.getFirstChild();
 
-        for (DetailNode node : javadoc.getChildren()) {
-            if (node.getType() == JavadocTokenTypes.JAVADOC_TAG) {
-                final String tagText = JavadocUtil.getFirstChild(node).getText();
-                final int indexOfCurrentTag = tagOrder.indexOf(tagText);
+        while (node != null) {
+            if (node.getType() == JavadocCommentsTokenTypes.JAVADOC_BLOCK_TAG) {
+                final String tagText = JavadocUtil.getTagName(node);
+                final int indexOfCurrentTag = tagOrder.indexOf("@" + tagText);
 
                 if (indexOfCurrentTag != -1) {
                     if (indexOfCurrentTag < maxIndexOfPreviousTag) {
@@ -213,6 +214,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
                     }
                 }
             }
+            node = node.getNextSibling();
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -22,14 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck.MSG_KEY;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
-@Disabled
 public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
 
     @Override


### PR DESCRIPTION
I cherry-picked another commit that fixes a parsing problem that was impacting this check and causing regression.

I don't understand exactly why we use "atclause" and not "javadoc block tags"